### PR TITLE
Use new app name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-JobTracker::Application.load_tasks
+Suitor::Application.load_tasks

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
-module JobTracker
+module Suitor
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
-JobTracker::Application.initialize!
+Suitor::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-JobTracker::Application.configure do
+Suitor::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-JobTracker::Application.configure do
+Suitor::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-JobTracker::Application.configure do
+Suitor::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-JobTracker::Application.config.session_store :cookie_store, key: '_job-tracker_session'
+Suitor::Application.config.session_store :cookie_store, key: '_job-tracker_session'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-JobTracker::Application.routes.draw do
+Suitor::Application.routes.draw do
   resources :job_applications
 
   get "welcome/index"


### PR DESCRIPTION
Change the name of the app internally to `Suitor`.
