### PR TITLE
Use underscores instead of mixedCase for properties

### DIFF
--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -69,6 +69,6 @@ class JobApplicationsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def job_application_params
-      params.require(:job_application).permit(:dateSent, :coverLetter, :posting_id)
+      params.require(:job_application).permit(:date_sent, :cover_letter, :posting_id)
     end
 end

--- a/app/controllers/postings_controller.rb
+++ b/app/controllers/postings_controller.rb
@@ -46,9 +46,9 @@ class PostingsController < ApplicationController
 
   private 
     def posting_params
-        params.require(:posting).permit(:title, :description, :url, :datePosted, :jobLocation, 
-          :hiringOrganization, :hiringOrganizationUrl, :contactName, :contactEmail, 
-          :applicationUrl, :submissionRequirements)
+        params.require(:posting).permit(:title, :description, :url, :date_posted, :job_location, 
+          :hiring_organization, :hiring_organization_url, :contact_name, :contact_email, 
+          :application_url, :submission_requirements)
     end
 
 end

--- a/app/models/posting.rb
+++ b/app/models/posting.rb
@@ -4,7 +4,7 @@ class Posting < ActiveRecord::Base
   has_one :job_application
 
   def applied?
-    job_application and job_application.dateSent
+    job_application and job_application.date_sent
   end
 
 end

--- a/app/views/job_applications/_form.html.erb
+++ b/app/views/job_applications/_form.html.erb
@@ -12,12 +12,12 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :dateSent %><br>
-    <%= f.date_select :dateSent %>
+    <%= f.label :date_sent %><br>
+    <%= f.date_select :date_sent %>
   </div>
   <div class="field">
-    <%= f.label :coverLetter %><br>
-    <%= f.text_area :coverLetter %>
+    <%= f.label :cover_letter %><br>
+    <%= f.text_area :cover_letter %>
   </div>
   <div class="field">
     <%= f.label :posting_id %><br>

--- a/app/views/job_applications/index.html.erb
+++ b/app/views/job_applications/index.html.erb
@@ -3,8 +3,8 @@
 <table>
   <thead>
     <tr>
-      <th>Datesent</th>
-      <th>Coverletter</th>
+      <th>date_sent</th>
+      <th>cover_letter</th>
       <th>Posting</th>
       <th></th>
       <th></th>
@@ -15,8 +15,8 @@
   <tbody>
     <% @job_applications.each do |job_application| %>
       <tr>
-        <td><%= job_application.dateSent %></td>
-        <td><%= job_application.coverLetter %></td>
+        <td><%= job_application.date_sent %></td>
+        <td><%= job_application.cover_letter %></td>
         <td><%= job_application.posting %></td>
         <td><%= link_to 'Show', job_application %></td>
         <td><%= link_to 'Edit', edit_job_application_path(job_application) %></td>

--- a/app/views/job_applications/index.json.jbuilder
+++ b/app/views/job_applications/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@job_applications) do |job_application|
-  json.extract! job_application, :id, :dateSent, :coverLetter, :posting_id
+  json.extract! job_application, :id, :date_sent, :cover_letter, :posting_id
   json.url job_application_url(job_application, format: :json)
 end

--- a/app/views/job_applications/show.html.erb
+++ b/app/views/job_applications/show.html.erb
@@ -1,13 +1,13 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Datesent:</strong>
-  <%= @job_application.dateSent %>
+  <strong>date_sent:</strong>
+  <%= @job_application.date_sent %>
 </p>
 
 <p>
-  <strong>Coverletter:</strong>
-  <%= @job_application.coverLetter %>
+  <strong>cover_letter:</strong>
+  <%= @job_application.cover_letter %>
 </p>
 
 <p>

--- a/app/views/job_applications/show.json.jbuilder
+++ b/app/views/job_applications/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @job_application, :id, :dateSent, :coverLetter, :posting_id, :created_at, :updated_at
+json.extract! @job_application, :id, :date_sent, :cover_letter, :posting_id, :created_at, :updated_at

--- a/app/views/postings/_form.html.erb
+++ b/app/views/postings/_form.html.erb
@@ -19,7 +19,7 @@
 
   <div>
     <%= f.label :'date posted' %>
-    <%= date_field(:posting, :datePosted) %>
+    <%= date_field(:posting, :date_posted) %>
   </div>
 
   <div>
@@ -35,17 +35,17 @@
   <h2>Company information</h2>
   <div>
     <%= f.label :company %>
-    <%= f.text_field :hiringOrganization %>
+    <%= f.text_field :hiring_organization %>
   </div>
 
   <div>
     <%= f.label :'company website' %>
-    <%= f.text_field :hiringOrganizationUrl %>
+    <%= f.text_field :hiring_organization_url %>
   </div>
 
   <div>
     <%= f.label :location %>
-    <%= f.text_field :jobLocation %>
+    <%= f.text_field :job_location %>
   </div>
 
 
@@ -54,22 +54,22 @@
   <h2>Application details</h2>
   <div>
     <%= f.label :contact %>
-    <%= f.text_field :contactName %>
+    <%= f.text_field :contact_name %>
   </div>
 
   <div>
     <%= f.label :'email' %>
-    <%= f.text_field :contactEmail %>
+    <%= f.text_field :contact_email %>
   </div>
 
   <div>
     <%= f.label :'application url' %>
-    <%= f.text_field :applicationUrl %>
+    <%= f.text_field :application_url %>
   </div>
 
   <div>
     <%= f.label :'submission requirements' %>
-    <%= f.text_field :submissionRequirements %>
+    <%= f.text_field :submission_requirements %>
   </div>
 
   <hr>

--- a/app/views/postings/index.html.erb
+++ b/app/views/postings/index.html.erb
@@ -32,7 +32,7 @@
 
 
       <div class="company">
-        <h2><%= link_to posting.hiringOrganization, posting %></h2>
+        <h2><%= link_to posting.hiring_organization, posting %></h2>
         <div class="notes">
           <%= simple_format(posting.description.truncate(300, separator: ' ')) %> 
           (<%= link_to 'More information', posting %>)
@@ -40,16 +40,16 @@
       </div>
 
       <ul class="job-details">
-        <% if posting.datePosted %>
-          <li><i class="icon-clock4"><span>Posted</span></i><%= posting.datePosted.strftime("%B %d") %></li>
+        <% if posting.date_posted %>
+          <li><i class="icon-clock4"><span>Posted</span></i><%= posting.date_posted.strftime("%B %d") %></li>
         <% end %>
 
-        <% if posting.jobLocation %>
-          <li><i class="icon-location4"><span>Location</span></i><%= posting.jobLocation %></li>
+        <% if posting.job_location %>
+          <li><i class="icon-location4"><span>Location</span></i><%= posting.job_location %></li>
        <% end %>
 
-        <% if posting.submissionRequirements %>
-          <li><i class="icon-key2"><span>Requires</span></i><%= posting.submissionRequirements.downcase %></li>
+        <% if posting.submission_requirements %>
+          <li><i class="icon-key2"><span>Requires</span></i><%= posting.submission_requirements.downcase %></li>
         <% end %>        
       </ul>
 

--- a/app/views/postings/show.html.erb
+++ b/app/views/postings/show.html.erb
@@ -1,6 +1,6 @@
 <header class="page-header">
   <h3><%= @posting.title %></h3>
-  <h1><%= @posting.hiringOrganization %></h1>
+  <h1><%= @posting.hiring_organization %></h1>
 </header>
 
 
@@ -19,42 +19,42 @@
   </div>
 
   <ul class="job-details">
-    <% if @posting.datePosted %>
-      <li><i class="icon-clock4"><span>Posted</span></i><%= @posting.datePosted.strftime("%B %d") %>
+    <% if @posting.date_posted %>
+      <li><i class="icon-clock4"><span>Posted</span></i><%= @posting.date_posted.strftime("%B %d") %>
       (<%= link_to_if @posting.url, "Original post", @posting.url %>)
       </li>
     <% end %>
 
-    <% if @posting.hiringOrganization %>
+    <% if @posting.hiring_organization %>
       <li><i class="icon-location4"><span>Employer</span></i>
-      <% if @posting.hiringOrganizationUrl %>
-        <%= link_to @posting.hiringOrganization, @posting.hiringOrganizationUrl %>
+      <% if @posting.hiring_organization_url %>
+        <%= link_to @posting.hiring_organization, @posting.hiring_organization_url %>
       <% else %>
-        <%= @posting.hiringOrganization %>
+        <%= @posting.hiring_organization %>
       <% end %>
-      <% if @posting.jobLocation %>(<%= @posting.jobLocation %>)<% end %>
+      <% if @posting.job_location %>(<%= @posting.job_location %>)<% end %>
       </li>
     <% end %>
 
-    <% if !@posting.applicationUrl.empty? %>
-      <li><i class="icon-external-link"><span>Online application</span></i><%= link_to 'URL', @posting.applicationUrl %></li>
+    <% if !@posting.application_url.empty? %>
+      <li><i class="icon-external-link"><span>Online application</span></i><%= link_to 'URL', @posting.application_url %></li>
     <% end %>
 
-    <% if !@posting.contactName.empty? or !@posting.contactEmail.empty? %>
+    <% if !@posting.contact_name.empty? or !@posting.contact_email.empty? %>
       <li><i class="icon-user6"><span>Contact</span></i>
-      <% if @posting.contactName.empty? %>
-        <%= link_to @posting.contactEmail, @posting.contactEmail %>
-      <% elsif @posting.contactEmail.empty? %>
-        <%= @posting.contactName %>
+      <% if @posting.contact_name.empty? %>
+        <%= link_to @posting.contact_email, @posting.contact_email %>
+      <% elsif @posting.contact_email.empty? %>
+        <%= @posting.contact_name %>
       <% else %>
-        <%= link_to @posting.contactName, @posting.contactEmail %>
+        <%= link_to @posting.contact_name, @posting.contact_email %>
       <% end %>
       </li>
 
     <% end %>
 
-    <% if @posting.submissionRequirements %>
-      <li><i class="icon-key2"><span>Application requirements</span></i><%= @posting.submissionRequirements.downcase %></li>
+    <% if @posting.submission_requirements %>
+      <li><i class="icon-key2"><span>Application requirements</span></i><%= @posting.submission_requirements.downcase %></li>
     <% end %>        
   </ul>
 
@@ -72,9 +72,9 @@
   <% if @posting.applied? %>
   <div class="accordion">
     <h3><i class="applied icon-checkmark done"><span>Application sent</span></i>
-    <%= @posting.job_application.dateSent.strftime("%B %d") %></h3>
+    <%= @posting.job_application.date_sent.strftime("%B %d") %></h3>
     <div class="notes">
-      <%= simple_format(@posting.job_application.coverLetter) %>
+      <%= simple_format(@posting.job_application.cover_letter) %>
     </div>
   </div>
 
@@ -84,10 +84,10 @@
     <%= form_for(@posting.job_application) do |f| %>
 
       <%= f.label :"Date applied" %>
-      <%= date_field :job_application, :dateSent, value: @posting.job_application.dateSent %>
+      <%= date_field :job_application, :date_sent, value: @posting.job_application.date_sent %>
 
       <%= f.label :"Enter cover letter and/or notes." %>
-      <%= f.text_area :coverLetter %>
+      <%= f.text_area :cover_letter %>
 
       <%= button_tag(:type => 'submit') do %>
         <i class="icon-checkmark"></i>Mark as applied

--- a/db/migrate/20140311210836_add_details_to_postings.rb
+++ b/db/migrate/20140311210836_add_details_to_postings.rb
@@ -1,13 +1,13 @@
 class AddDetailsToPostings < ActiveRecord::Migration
   def change
     add_column :postings, :url, :string
-    add_column :postings, :datePosted, :date
-    add_column :postings, :jobLocation, :string
-    add_column :postings, :hiringOrganization, :string
-    add_column :postings, :hiringOrganizationUrl, :string
-    add_column :postings, :contactName, :string
-    add_column :postings, :contactEmail, :string
-    add_column :postings, :applicationUrl, :string
-    add_column :postings, :submissionRequirements, :string
+    add_column :postings, :date_posted, :date
+    add_column :postings, :job_location, :string
+    add_column :postings, :hiring_organization, :string
+    add_column :postings, :hiring_organization_url, :string
+    add_column :postings, :contact_name, :string
+    add_column :postings, :contact_email, :string
+    add_column :postings, :application_url, :string
+    add_column :postings, :submission_requirements, :string
   end
 end

--- a/db/migrate/20140317190456_create_job_applications.rb
+++ b/db/migrate/20140317190456_create_job_applications.rb
@@ -1,8 +1,8 @@
 class CreateJobApplications < ActiveRecord::Migration
   def change
     create_table :job_applications do |t|
-      t.date :dateSent
-      t.text :coverLetter
+      t.date :date_sent
+      t.text :cover_letter
       t.references :posting, index: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,19 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20140317190456) do
 
-  create_table "applications", force: true do |t|
-    t.date     "dateSent"
-    t.text     "coverLetter"
-    t.integer  "posting_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "applications", ["posting_id"], name: "index_applications_on_posting_id"
-
   create_table "job_applications", force: true do |t|
-    t.date     "dateSent"
-    t.text     "coverLetter"
+    t.date     "date_sent"
+    t.text     "cover_letter"
     t.integer  "posting_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -33,25 +23,20 @@ ActiveRecord::Schema.define(version: 20140317190456) do
 
   add_index "job_applications", ["posting_id"], name: "index_job_applications_on_posting_id"
 
-  create_table "job_postings", force: true do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "postings", force: true do |t|
     t.string   "title"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "url"
-    t.date     "datePosted"
-    t.string   "jobLocation"
-    t.string   "hiringOrganization"
-    t.string   "hiringOrganizationUrl"
-    t.string   "contactName"
-    t.string   "contactEmail"
-    t.string   "applicationUrl"
-    t.string   "submissionRequirements"
+    t.date     "date_posted"
+    t.string   "job_location"
+    t.string   "hiring_organization"
+    t.string   "hiring_organization_url"
+    t.string   "contact_name"
+    t.string   "contact_email"
+    t.string   "application_url"
+    t.string   "submission_requirements"
   end
 
 end

--- a/test/controllers/job_applications_controller_test.rb
+++ b/test/controllers/job_applications_controller_test.rb
@@ -18,7 +18,7 @@ class JobApplicationsControllerTest < ActionController::TestCase
 
   test "should create job_application" do
     assert_difference('JobApplication.count') do
-      post :create, job_application: { coverLetter: @job_application.coverLetter, dateSent: @job_application.dateSent, posting_id: @job_application.posting_id }
+      post :create, job_application: { cover_letter: @job_application.cover_letter, date_sent: @job_application.date_sent, posting_id: @job_application.posting_id }
     end
 
     assert_redirected_to job_application_path(assigns(:job_application))
@@ -35,7 +35,7 @@ class JobApplicationsControllerTest < ActionController::TestCase
   end
 
   test "should update job_application" do
-    patch :update, id: @job_application, job_application: { coverLetter: @job_application.coverLetter, dateSent: @job_application.dateSent, posting_id: @job_application.posting_id }
+    patch :update, id: @job_application, job_application: { cover_letter: @job_application.cover_letter, date_sent: @job_application.date_sent, posting_id: @job_application.posting_id }
     assert_redirected_to job_application_path(assigns(:job_application))
   end
 

--- a/test/fixtures/job_applications.yml
+++ b/test/fixtures/job_applications.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  dateSent: 2014-03-17
-  coverLetter: MyText
+  date_sent: 2014-03-17
+  cover_letter: MyText
   posting_id: 
 
 two:
-  dateSent: 2014-03-17
-  coverLetter: MyText
+  date_sent: 2014-03-17
+  cover_letter: MyText
   posting_id: 


### PR DESCRIPTION
This uses Rails/Ruby underscores for properties rather than mixedCase. It overwrites a migration so existing databases need to be altered by hand or deleted.
