### PR TITLE
Show current user in footnotes

### DIFF
--- a/app/controllers/postings_controller.rb
+++ b/app/controllers/postings_controller.rb
@@ -11,13 +11,10 @@ class PostingsController < ApplicationController
         @postings = Posting.sorted_by_importance
       when 'status'
         @postings = Posting.sorted_by_status
-    else 
+    else
       @postings = Posting.sorted_by_importance
       @sortorder = 'importance'
     end
-
-    # Check for any filters.
-    @postings = @postings.send(params[:filter].to_sym) if Posting.valid_scope?(params[:filter])
   end
 
   def archived

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,5 +30,4 @@ Suitor::Application.configure do
 
   # Let's set a timezone so I get less confused
   config.time_zone = 'Eastern Time (US & Canada)'
-
 end

--- a/config/initializers/rails_footnotes.rb
+++ b/config/initializers/rails_footnotes.rb
@@ -9,6 +9,7 @@ defined?(Footnotes) && Footnotes.setup do |f|
 
   # Only toggle some notes :
   # f.notes = [:session, :cookies, :params, :filters, :routes, :env, :queries, :log, :general]
+  f.notes += [:current_user]
 
   # Change the prefix :
   # f.prefix = 'mvim://open?url=file://%s&line=%d&column=%d'
@@ -24,4 +25,37 @@ defined?(Footnotes) && Footnotes.setup do |f|
 
   # Allow to open multiple notes :
   # f.multiple_notes = true
+end
+
+if defined?(Footnotes)
+  module Footnotes
+    module Notes
+      class CurrentUserNote < AbstractNote
+        # This method always receives a controller
+        #
+        def initialize(controller)
+          @current_user = controller.instance_variable_get("@current_user")
+        end
+
+        # Returns the title that represents this note.
+        #
+        def title
+          "Current user: #{@current_user.email}"
+        end
+
+        # This Note is only valid if we actually found an user
+        # If it's not valid, it won't be displayed
+        #
+        def valid?
+          @current_user
+        end
+
+        # The fieldset content
+        #
+        def content
+          escape(@current_user.inspect)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Just shows current user info in the footnotes section during development; nothing fancy.
