### PR TITLE
Add focus class to textarea's containing div.

### DIFF
--- a/app/assets/javascripts/layout.js.coffee
+++ b/app/assets/javascripts/layout.js.coffee
@@ -15,16 +15,10 @@ $ ->
       this.closest(element).find('.tooltip').remove()
 
     # Add focus classes to container divs when an input/textarea is focused on (used for styling)
-    $("input").focus ->
-      $(this).parent().addClass "focus"
-      
-    $("input").blur ->
-      $(this).parent().removeClass "focus"
-
-    $("textarea").focus ->
+    $("input,textarea").focus ->
       $(this).parent().addClass "focus"
 
-    $("textarea").blur ->
+    $("input,textarea").blur ->
       $(this).parent().removeClass "focus"
 
     # Make some custom tooltips happen (for form elements only, at least right now)

--- a/app/assets/javascripts/layout.js.coffee
+++ b/app/assets/javascripts/layout.js.coffee
@@ -17,19 +17,15 @@ $ ->
     # Add focus classes to container divs when an input/textarea is focused on (used for styling)
     $("input").focus ->
       $(this).parent().addClass "focus"
-      return
-
+      
     $("input").blur ->
       $(this).parent().removeClass "focus"
-      return
 
     $("textarea").focus ->
       $(this).parent().addClass "focus"
-      return
 
     $("textarea").blur ->
       $(this).parent().removeClass "focus"
-      return
 
     # Make some custom tooltips happen (for form elements only, at least right now)
     $('label').mouseover ->

--- a/app/assets/javascripts/layout.js.coffee
+++ b/app/assets/javascripts/layout.js.coffee
@@ -14,6 +14,23 @@ $ ->
       this.attr "title", this.data("title")
       this.closest(element).find('.tooltip').remove()
 
+    # Add focus classes to container divs when an input/textarea is focused on (used for styling)
+    $("input").focus ->
+      $(this).parent().addClass "focus"
+      return
+
+    $("input").blur ->
+      $(this).parent().removeClass "focus"
+      return
+
+    $("textarea").focus ->
+      $(this).parent().addClass "focus"
+      return
+
+    $("textarea").blur ->
+      $(this).parent().removeClass "focus"
+      return
+
     # Make some custom tooltips happen (for form elements only, at least right now)
     $('label').mouseover ->
       if $(this).attr("title")

--- a/app/assets/javascripts/postings.js.coffee
+++ b/app/assets/javascripts/postings.js.coffee
@@ -34,14 +34,6 @@ $ ->
         "h4"
       ]
 
-    $("input").focus ->
-      $(this).parent().addClass "focus"
-      return
-
-    $("input").blur ->
-      $(this).parent().removeClass "focus"
-      return
-
     # Show submitted application details in a modal
     $(".applied.done").on "click", ->
         vex.dialog.alert


### PR DESCRIPTION
Low-hanging fruit is my airport jam. Fixes #145. 

Needs to be integrated with the texteditor, but since this one's a placeholder, I'll leave it be for now.
